### PR TITLE
fix bug in read_leaves_in_string_order()

### DIFF
--- a/tcmc/nwk_utils.py
+++ b/tcmc/nwk_utils.py
@@ -179,7 +179,7 @@ def read_leaves_in_string_order(nwk_tree_string):
     # these are precisely those nodes which do not have children
     # i.e. to the left of the node is either a '(' or ',' character
     # or the beginning of the line
-    leave_regex = re.compile('(?:^|[(,])([\w]*)[:](?:(?:[0-9]*[.])?[0-9]+)')
+    leave_regex = re.compile('(?:^|[(,])([\w.-]*)[:](?:(?:[0-9]*[.])?[0-9]+)')
     
     matches = leave_regex.findall(nwk_tree_string)
     


### PR DESCRIPTION
I have fixed a bug in read_leaves_in_string_order(). There was an IndexError if the specis name contains a number. But there is still a bug. You can not read all trees with this function. The default tree from http://etetoolkit.org/treeview/ does not work.